### PR TITLE
`--start-time` が未指定の場合はSDKのStartTimeにも指定しない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# tags
+tags

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"math"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	Aws "github.com/cm-igarashi-ryosuke/lazy-awslogs/lib/aws"
@@ -45,10 +44,10 @@ func (this *GetFlags) GetCloudWatchLogsFilterLogEventsParam() cloudwatchlogs.Fil
 		LogStreamNames: []*string{&this.Log.Stream},
 		FilterPattern:  &pattern,
 	}
-	if startTime != math.MaxInt64 {
+	if startTime != 0 {
 		input.StartTime = &startTime
 	}
-	if endTime != math.MaxInt64 {
+	if endTime != 0 {
 		input.EndTime = &endTime
 	}
 	return input
@@ -62,10 +61,10 @@ func (this *GetFlags) GetCloudWatchLogsGetLogEventsParam() cloudwatchlogs.GetLog
 		LogGroupName:  &this.Log.Group,
 		LogStreamName: &this.Log.Stream,
 	}
-	if startTime != math.MaxInt64 {
+	if startTime != 0 {
 		input.StartTime = &startTime
 	}
-	if endTime != math.MaxInt64 {
+	if endTime != 0 {
 		input.EndTime = &endTime
 	}
 	return input

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"math"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	Aws "github.com/cm-igarashi-ryosuke/lazy-awslogs/lib/aws"
@@ -39,25 +40,35 @@ func (this *GetFlags) GetCloudWatchLogsFilterLogEventsParam() cloudwatchlogs.Fil
 	startTime := this.TimeRange.StartTimeMilliseconds()
 	endTime := this.TimeRange.EndTimeMilliseconds()
 	pattern := fmt.Sprintf("\"%s\"", this.Pattern)
-	return cloudwatchlogs.FilterLogEventsInput{
+	input := cloudwatchlogs.FilterLogEventsInput{
 		LogGroupName:   &this.Log.Group,
 		LogStreamNames: []*string{&this.Log.Stream},
-		StartTime:      &startTime,
-		EndTime:        &endTime,
 		FilterPattern:  &pattern,
 	}
+	if startTime != math.MaxInt64 {
+		input.StartTime = &startTime
+	}
+	if endTime != math.MaxInt64 {
+		input.EndTime = &endTime
+	}
+	return input
 }
 
 // Create GetLogEventsInput by GetFlags
 func (this *GetFlags) GetCloudWatchLogsGetLogEventsParam() cloudwatchlogs.GetLogEventsInput {
 	startTime := this.TimeRange.StartTimeMilliseconds()
 	endTime := this.TimeRange.EndTimeMilliseconds()
-	return cloudwatchlogs.GetLogEventsInput{
+	input := cloudwatchlogs.GetLogEventsInput{
 		LogGroupName:  &this.Log.Group,
 		LogStreamName: &this.Log.Stream,
-		StartTime:     &startTime,
-		EndTime:       &endTime,
 	}
+	if startTime != math.MaxInt64 {
+		input.StartTime = &startTime
+	}
+	if endTime != math.MaxInt64 {
+		input.EndTime = &endTime
+	}
+	return input
 }
 
 var _getFlags = &GetFlags{}
@@ -136,7 +147,7 @@ func getRun(cmd *cobra.Command, args []string) {
 	}
 	if err != nil {
 		fmt.Println(err.Error())
-		os.Exit(2) // TODO: exit codeも仕様明記しないと
+		os.Exit(2)
 	}
 }
 

--- a/lib/flags/time_range.go
+++ b/lib/flags/time_range.go
@@ -18,6 +18,9 @@ func (this *CWLogTimeRange) String() string {
 }
 
 func (this *CWLogTimeRange) StartTimeMilliseconds() int64 {
+	if this.startString == "" {
+		return 0
+	}
 	time, err := KindlyTime.ParseBaseOnCurrentTime(this.startString)
 	if err != nil {
 		fmt.Errorf("Unrecognized start-time option -- %s\n", err.Error())
@@ -27,6 +30,9 @@ func (this *CWLogTimeRange) StartTimeMilliseconds() int64 {
 }
 
 func (this *CWLogTimeRange) EndTimeMilliseconds() int64 {
+	if this.endString == "" {
+		return 0
+	}
 	time, err := KindlyTime.ParseBaseOnCurrentTime(this.endString)
 	if err != nil {
 		fmt.Errorf("Unrecognized end-time option -- %s\n", err.Error())
@@ -37,6 +43,6 @@ func (this *CWLogTimeRange) EndTimeMilliseconds() int64 {
 
 // pflag.FlagSetからCWLogTimeRangeをロードする
 func (this *CWLogTimeRange) Load(pflag *Pflag.FlagSet) {
-	pflag.StringVarP(&this.startString, "start-time", "", "30 minutes ago", "The start of the time range, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC. Events with a timestamp earlier than this time are not included.")
-	pflag.StringVarP(&this.endString, "end-time", "", "now", "The end of the time range, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC. Events with a timestamp later than this time are not included.")
+	pflag.StringVarP(&this.startString, "start-time", "", "", "The start of the time range, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC. Events with a timestamp earlier than this time are not included.")
+	pflag.StringVarP(&this.endString, "end-time", "", "", "The end of the time range, expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC. Events with a timestamp later than this time are not included.")
 }


### PR DESCRIPTION
- デフォルト値を空文字列にする
- 空文字列の場合、int64としては0にする(Unix epoch 0)
- 0の場合は aws-sdk-go に渡さない
- `--end-time` も同様
