### PR TITLE
Fix/no credential providers

### DIFF
--- a/lib/aws/aws.go
+++ b/lib/aws/aws.go
@@ -40,8 +40,9 @@ func NewCloudWatchLogsClient(params CloudWatchLogsClientParams) CloudWatchLogsCl
 		}
 		sess = session.Must(session.NewSessionWithOptions(session.Options{
 			// If both Config and Profile are present, Config will be given preference.
-			Config:  config,
-			Profile: params.Profile,
+			Config:            config,
+			Profile:           params.Profile,
+			SharedConfigState: session.SharedConfigEnable,
 		}))
 	}
 	return CloudWatchLogsClient{cwLogs: cloudwatchlogs.New(sess)}


### PR DESCRIPTION
## Note
If no SharedConfigState, raise error `NoCredentialProviders`.

## e.g.
https://github.com/aws/aws-sdk-go#configuring-credentials
> The SDK has support for the shared configuration file (~/.aws/config). This support can be enabled by setting the environment variable, "AWS_SDK_LOAD_CONFIG=1", or enabling the feature in code when creating a Session via the Option's SharedConfigState parameter.

## Issue
#21